### PR TITLE
Remove the acknowledge checkbox for solution_deployment_view

### DIFF
--- a/cloud-service-providers/google-cloud/gke/metadata.display.yaml
+++ b/cloud-service-providers/google-cloud/gke/metadata.display.yaml
@@ -30,16 +30,6 @@ spec:
           title: Additional Labels
           invisible: true
           section: required_config
-        solution_deployment_view:
-          name: solution_deployment_view
-          title: Check to confirm that upon deployment completion, you need to go to the Solution deployment page, find your deployment, and follow suggested next steps on the deployment DETAILS tab.
-          section: acknowledge
-          subtext: <p>
-                    <a href="https://console.cloud.google.com/products/solutions/deployments"><i>Solution deployment page</i></a>
-                   </p>
-          enumValueLabels:
-            - label: Confirm that all prerequisites have been met.
-              value: "true"
         #cluster_location:
         #  name: cluster_location
         #  title: Cluster Location

--- a/cloud-service-providers/google-cloud/gke/metadata.yaml
+++ b/cloud-service-providers/google-cloud/gke/metadata.yaml
@@ -24,9 +24,6 @@ spec:
         description: Additional labels to add to Kubernetes resources.
         varType: string
         defaultValue: "created-by=gke-ai-quick-start-solutions,ai.gke.io=nim"
-      - name: solution_deployment_view
-        varType: bool
-        required: true
       #- name: cluster_location
       #  varType: string
       #  required: true


### PR DESCRIPTION
With the new GKE ML/AI UI, users of QSS don't need to go to the MP Solution deployment view page to view the deployment details. So remove the related acknowledge checkbox from the form.