### PR TITLE
feat: enable image streaming on gpu np

### DIFF
--- a/cloud-service-providers/google-cloud/gke/terraform/modules/bootstrap/main.tf
+++ b/cloud-service-providers/google-cloud/gke/terraform/modules/bootstrap/main.tf
@@ -27,6 +27,7 @@ locals {
     "servicenetworking.googleapis.com",
     "stackdriver.googleapis.com",
     "storage.googleapis.com",
+    "containerfilesystem.googleapis.com",
   ]
   services = concat(local.default_services, var.services)
 }

--- a/cloud-service-providers/google-cloud/gke/variables.tf
+++ b/cloud-service-providers/google-cloud/gke/variables.tf
@@ -269,6 +269,7 @@ variable "gpu_pools" {
     gpu_driver_version     = "DEFAULT"
     service_account        = ""
     create_service_account = false
+    enable_gcfs            = true
   }]
 }
 


### PR DESCRIPTION
Enable Image streaming on GPU node pool to initialize without waiting for the entire image to download, which leads to significant improvements in initialization times