### PR TITLE
fixed wrong local ssd count for `g2-standard-24`

### DIFF
--- a/cloud-service-providers/google-cloud/gke/variables.tf
+++ b/cloud-service-providers/google-cloud/gke/variables.tf
@@ -371,7 +371,7 @@ variable "vm_gpu_spec_list" {
     g2-standard-24 = {
       accelerator_type  = "nvidia-l4"
       accelerator_count = 2
-      local_ssd_count   = 1
+      local_ssd_count   = 2
       gpu_family        = "l4"
     }
     g2-standard-32 = {


### PR DESCRIPTION
<img width="1345" alt="image" src="https://github.com/user-attachments/assets/a70158b6-6947-4b16-9693-8e5cc1f8b106" />

Per documentation https://cloud.google.com/compute/docs/disks/local-ssd?_gl=1*op2d7z*_ga*MjAxMTM2NTk0MC4xNzQxMjIyMzk2*_ga_WH2QY8WWF5*MTc0MTI4MzQ2Ni41LjEuMTc0MTI4Mzc0OC41NC4wLjA.#choose_number_local_ssds the `local_ssd_count` for `g2-standard-24` should be 2, not 1