### PR TITLE
fix: redist packages used in fetch url and k8s cluster

### DIFF
--- a/cloud-service-providers/google-cloud/gke/fetch-ngc-url.sh
+++ b/cloud-service-providers/google-cloud/gke/fetch-ngc-url.sh
@@ -2,43 +2,32 @@
 
 TEMP_DIR="$(mktemp -d)"
 
-if ! which curl > /dev/null; then
-  CURL_VERSION=8.10.1
-  wget -q "https://github.com/stunnel/static-curl/releases/download/${CURL_VERSION}/curl-linux-x86_64-${CURL_VERSION}.tar.xz" -P "$TEMP_DIR"
-  tar xf "$TEMP_DIR/curl-linux-x86_64-${CURL_VERSION}.tar.xz" -C "$TEMP_DIR"
-  alias curl="$TEMP_DIR/curl"
-fi
+alias curl="./redist/curl/curl"
+alias jq="./redist/jq/jq"
 
-if ! which jq > /dev/null; then
-  JQ_VERSION=1.7
-  wget -q "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64" -O "$TEMP_DIR/jq"
-  chmod +x "$TEMP_DIR/jq"
-  alias jq="$TEMP_DIR/jq"
-fi
-
-if ! which gcloud > /dev/null; then
-  cat <<EOF > "$TEMP_DIR/id_request.json"
+if ! which gcloud >/dev/null; then
+	cat <<EOF >"$TEMP_DIR/id_request.json"
 {
 "audience": "https://${SERVICE_FQDN}",
 "includeEmail": "true"
 }
 EOF
 
-  TOKEN="$(curl -s -X GET -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" | jq -r ".access_token")"
+	TOKEN="$(curl -s -X GET -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" | jq -r ".access_token")"
 
-  EMAIL="$(curl -s -X GET -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email")"
+	EMAIL="$(curl -s -X GET -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email")"
 
-  ID_TOKEN="$(curl -s -X POST \
-    -H "Authorization: Bearer $TOKEN" \
-    -H "Content-Type: application/json; charset=utf-8" \
-    -d "@$TEMP_DIR/id_request.json" \
-    "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${EMAIL}:generateIdToken" | jq -r ".token")"
+	ID_TOKEN="$(curl -s -X POST \
+		-H "Authorization: Bearer $TOKEN" \
+		-H "Content-Type: application/json; charset=utf-8" \
+		-d "@$TEMP_DIR/id_request.json" \
+		"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${EMAIL}:generateIdToken" | jq -r ".token")"
 
 else
-  ID_TOKEN="$(gcloud auth print-identity-token)"
+	ID_TOKEN="$(gcloud auth print-identity-token)"
 fi
 
-cat <<EOF > "$TEMP_DIR/req.cred.json"
+cat <<EOF >"$TEMP_DIR/req.cred.json"
 {
   "bucket": "${NIM_GCS_BUCKET}",
   "text": "${NGC_EULA_TEXT}",

--- a/cloud-service-providers/google-cloud/gke/k8s-exec-token.sh
+++ b/cloud-service-providers/google-cloud/gke/k8s-exec-token.sh
@@ -1,27 +1,20 @@
+#!/bin/sh
+
 UTIL_DIR=/tmp/k8s-exec-token-plugin
 mkdir -p "$UTIL_DIR"
 
-if [ ! -f "$UTIL_DIR/curl" ]; then
-  CURL_VERSION=8.10.1
-  wget -q "https://github.com/stunnel/static-curl/releases/download/${CURL_VERSION}/curl-linux-x86_64-${CURL_VERSION}.tar.xz" -P "$UTIL_DIR"
-  tar xf "$UTIL_DIR/curl-linux-x86_64-${CURL_VERSION}.tar.xz" -C "$UTIL_DIR"
-fi
+alias curl="./redist/curl/curl"
+alias jq="./redist/jq/jq"
 
-if [ ! -f "$UTIL_DIR/jq" ]; then
-  JQ_VERSION=1.7
-  wget -q "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64" -O "$UTIL_DIR/jq"
-  chmod +x "$UTIL_DIR/jq"
-fi
+if ! which gke-gcloud-auth-plugin >/dev/null; then
+	RESULT="$(curl -s -X GET -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")"
+	ACCESS_TOKEN="$(echo $RESULT | jq -r ".access_token")"
+	EXPIRES_IN="$(echo $RESULT | jq -r ".expires_in")"
+	DATE_NOW="$(date +%s)"
+	EXPIRES_AT="$(expr $DATE_NOW + $EXPIRES_IN)"
+	EXPIRATION_TIMESTAMP="$(date -d@$EXPIRES_AT --utc +%Y-%m-%dT%H:%M:%SZ)"
 
-if ! which gke-gcloud-auth-plugin > /dev/null; then
-  RESULT="$($UTIL_DIR/curl -s -X GET -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")"
-  ACCESS_TOKEN="$(echo $RESULT | $UTIL_DIR/jq -r ".access_token")"
-  EXPIRES_IN="$(echo $RESULT | $UTIL_DIR/jq -r ".expires_in")"
-  DATE_NOW="$(date +%s)"
-  EXPIRES_AT="$(expr $DATE_NOW + $EXPIRES_IN)"
-  EXPIRATION_TIMESTAMP="$(date -d@$EXPIRES_AT --utc +%Y-%m-%dT%H:%M:%SZ)"
-
-  cat <<EOF
+	cat <<EOF
 {
     "kind": "ExecCredential",
     "apiVersion": "client.authentication.k8s.io/v1beta1",
@@ -35,5 +28,5 @@ if ! which gke-gcloud-auth-plugin > /dev/null; then
 }
 EOF
 else
-  gke-gcloud-auth-plugin
+	gke-gcloud-auth-plugin
 fi

--- a/cloud-service-providers/google-cloud/gke/redist/download_redist.sh
+++ b/cloud-service-providers/google-cloud/gke/redist/download_redist.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+CURL_VERSION=8.10.1
+JQ_VERSION=1.7
+
+wget -q "https://github.com/stunnel/static-curl/releases/download/${CURL_VERSION}/curl-linux-x86_64-${CURL_VERSION}.tar.xz" -P ./curl
+
+mkdir "./jq"
+wget -q "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64" -O "jq/jq"
+
+tar xf curl/curl-linux-x86_64-${CURL_VERSION}.tar.xz -C ./curl
+chmod +x curl/curl
+chmod +x jq/jq
+
+rm -r curl/curl-linux-x86_64-${CURL_VERSION}.tar.xz


### PR DESCRIPTION
Changes
 - wget dependency removed from .sh scripts
 - package `curl` https://github.com/stunnel/static-curl?tab=MIT-1-ov-file
 - package `jq`: license https://github.com/jqlang/jq?tab=License-1-ov-file 